### PR TITLE
Fixed getOverview intent

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -104,7 +104,7 @@ var newSessionHandlers = {
 var startSearchHandlers = Alexa.CreateStateHandler(states.SEARCHMODE, {
     'getOverview': function () {
         output = locationOverview;
-        this.emit(':tellWithCard', output, output, locationOverview);
+        this.emit(':tellWithCard', output, location, locationOverview);
     },
     'getAttractionIntent': function () {
         var cardTitle = location;


### PR DESCRIPTION
the "tell me about {location}" getOverview intent was returning an error upon testing & failed certification. This fixes that. Solution taken from https://github.com/alexa/skill-sample-nodejs-city-guide/issues/6